### PR TITLE
Update Schemas

### DIFF
--- a/translations-identification-models/json-schema.json
+++ b/translations-identification-models/json-schema.json
@@ -16,9 +16,14 @@
         "description": "The name of the language identification model"
       },
       "version": {
-        "type": "number",
+        "type": "string",
         "title": "Version",
         "description": "The version of the model"
+      },
+      "filter_expression": {
+        "type": "string",
+        "title": "Filter Expression",
+        "description": "A JEXL to filter records"
       }
     }
   },

--- a/translations-models/json-schema.json
+++ b/translations-models/json-schema.json
@@ -10,6 +10,9 @@
       "fileType"
     ],
     "properties": {
+      "id": {
+        "type": "string"
+      },
       "name": {
         "type": "string",
         "title": "Name",
@@ -21,7 +24,7 @@
         "description": "The BCP 47 language tag that will be translated to"
       },
       "version": {
-        "type": "number",
+        "type": "string",
         "title": "Version",
         "description": "The version of the model"
       },
@@ -39,6 +42,11 @@
         "type": "string",
         "title": "From Language",
         "description": "The BCP 47 language tag that will be translated from"
+      },
+      "filter_expression": {
+        "type": "string",
+        "title": "Filter Expression",
+        "description": "A JEXL to filter records"
       }
     }
   },

--- a/translations-wasm/json-schema.json
+++ b/translations-wasm/json-schema.json
@@ -9,10 +9,18 @@
       "license"
     ],
     "properties": {
+      "id": {
+        "type": "string"
+      },
       "name": {
         "type": "string",
         "title": "Name",
         "description": "The name of the project, e.g. bergamot-translator"
+      },
+      "license": {
+        "type": "string",
+        "title": "License",
+        "description": "The license of the wasm, as a https://spdx.org/licenses/"
       },
       "release": {
         "type": "string",
@@ -24,10 +32,10 @@
         "title": "Revision",
         "description": "The commit hash for the project that generated the wasm."
       },
-      "license": {
+      "filter_expression": {
         "type": "string",
-        "title": "License",
-        "description": "The license of the wasm, as a https://spdx.org/licenses/"
+        "title": "Filter Expression",
+        "description": "A JEXL to filter records"
       }
     }
   },


### PR DESCRIPTION
Updates the schemas to have `version` as a string instead of a number. 
Updates the schemas to all have a filter_expression attribute.
Ensures all schemas have the `id` attribute.